### PR TITLE
feat(docker): Add phpmyadmin

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.8"
 services:
   database:
     image: mariadb:11.0.2
-    restart: always
     environment:
       - MARIADB_ROOT_PASSWORD=root
     volumes:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,7 +1,7 @@
-version: '3.9'
+version: "3.8"
+
 services:
   database:
-    container_name: greengame
     image: mariadb:11.0.2
     restart: always
     environment:
@@ -11,3 +11,10 @@ services:
       - ./dump:/docker-entrypoint-initdb.d
     ports:
       - "3306:3306"
+
+  phpmyadmin:
+    image: phpmyadmin
+    ports:
+      - "8000:80"
+    environment:
+      - PMA_HOST=database


### PR DESCRIPTION
Adds phpmyadmin that exposes port `8000`. Removes `restart: always` for database.